### PR TITLE
Accept Svelte 5 as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"!dist/**/*.spec.*"
 	],
 	"peerDependencies": {
-		"svelte": "^4.0.0"
+		"svelte": "^4.0.0 || "^5.0.0"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^3.3.1",


### PR DESCRIPTION
I'm currently getting an error with this package when trying to deploy to Vercel, which uses a stricter npm peer dependency rule than my local server.

Simply declaring Svelte 5 as well lets npm know that the package works with Svelte 5 as well and fixes the error message.